### PR TITLE
Added Path instructions to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ Install rustybox
 cargo install --path .
 ```
 
+If the `rustybox` command can't be found, be sure to add the default cargo installation folder into the PATH environment variable
+
+```bash
+export PATH=/home/<your username here>/.cargo/bin:$PATH
+```
+
 Run tests
 
 ```bash


### PR DESCRIPTION
Updated `README.md` to include instruction on how to add the default `cargo install` installation location to the Path environment variable. This may be relevant to Arch Linux users. 